### PR TITLE
Atualizar o README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ pip install git+https://github.com/discloud/python-discloud-status@dev
 ```
 
 ## Usage
-### Create client instance
+### Get Started
+First of all, you need to get your Discloud API-Token. You can create a new one by typing `.api` in the [Discloud Server](https://discord.gg/discloud).
+If you're in trouble on getting your Discloud API-Token, you can DM the Ticket bot (DisCloud ModMail#6424) in the server. The supporters will be glad on helping you
+
+### Creating a client
 ```python
 import discloud
-discloud_client = discloud.Client("Token")
+discloud_client = discloud.Client("API-Token")
 ```
 
-### Fetch user info
+### User info
 ```python
 user = await discloud_client.fetch_user_info()
 print(f"ID: '{user.id}'")
@@ -25,9 +29,9 @@ print(f"Expire date '{plan.expire_date}'")
 print(f"Ends in '{plan.expires_in}'")
 ```
 
-### Fetch bot info
+### Bot info
 ```python
-bot = await discloud_client.fetch_bot(bot_id=469310554108854274)
+bot = await discloud_client.fetch_bot(bot_id=BOT_ID)
 print(f"ID '{bot.id}'")
 print(f"Status '{bot.status}'")
 print(f"CPU '{bot.cpu}'")
@@ -39,30 +43,32 @@ print(f"Last restart '{bot.last_restart}'")
 
 ### Logs
 ```python
-logs = await discloud_client.fetch_logs(bot_id=ID_DO_BOT)
+logs = await discloud_client.fetch_logs(bot_id=BOT_ID)
 # or
 logs = await bot.fetch_logs()
 
-print(logs.url) # url for full logs
-
-print(str(logs))
-# or
-print(logs.text) # for last 1800 chars
+print(logs.url) # ".url" for a link with full logs
+print(logs.text) # ".text" for the last 1800 characters of your logs
 ```
 
 ### Restart
+`Bot.restart()`/`Client.restart_bot()` returns an Action, wich contains a `.message` attr so you can know if the reset was successful by printing it
 ```python
 result = await discloud_client.restart_bot(bot_id=BOT_ID)
 # or
 result = await bot.restart()
-print(result) # you will know if it was restarted
+
+print(result.message) # See if the restart was successful
 ```
 
 ### Commit
+`Bot.commit()`/`Client.commit()` returns an Action. Print the `.message` of it to know if the commit was successful. <br />
+`*.commit()` accepts the `restart` kwarg. Set it to True to restart the bot after a commit, False to not.
 ```python
-file = discloud.File("file.zip") # precisa ser em zip
-await discloud_client.commit(bot_id=BOT_ID, file=file, restart=True)
+file = discloud.File("eggs.zip") # Must be .zip
+result = await discloud_client.commit(bot_id=BOT_ID, file=file, restart=True)
 # or
-r = await bot.commit(file=file, restart=False)
-print(r) # know if commit was successful
+result = await bot.commit(file=file, restart=True)
+
+print(result.message) # See if the commit was successful
 ```

--- a/README_pt.md
+++ b/README_pt.md
@@ -8,7 +8,7 @@ Nota: precisa do https://git-scm.com
 pip install git+https://github.com/discloud/python-discloud-status@dev
 ```
 ## Uso
-### Inicando
+### Iniciando
 Antes de tudo, você precisa obter seu API-Token da Discloud. Você pode criar um novo digitando `.api` no [Servidor da Discloud](https://discord.gg/discloud).
 Se você estiver com problemas para obter seu API-Token, você pode enviar uma DM para o bot de Tickets da Discloud (DisCloud ModMail#6424) no servidor. Os apoiadores estarão felizes em ajudá-lo
 ```python

--- a/README_pt.md
+++ b/README_pt.md
@@ -7,7 +7,7 @@ Nota: precisa do https://git-scm.com
 ```
 pip install git+https://github.com/discloud/python-discloud-status@dev
 ```
-## Uso
+## Como usar
 ### Iniciando
 Antes de tudo, você precisa obter seu API-Token da Discloud. Você pode criar um novo digitando `.api` no [Servidor da Discloud](https://discord.gg/discloud).
 Se você estiver com problemas para obter seu API-Token, você pode enviar uma DM para o bot de Tickets da Discloud (DisCloud ModMail#6424) no servidor. Os apoiadores estarão felizes em ajudá-lo

--- a/README_pt.md
+++ b/README_pt.md
@@ -1,20 +1,22 @@
-## Instalacao
+## Instalando
 ```
 pip install discloud
 ```
-## Instalacao dev
+## Instalando o código para devs
 Nota: precisa do https://git-scm.com 
 ```
 pip install git+https://github.com/discloud/python-discloud-status@dev
 ```
 ## Uso
-### Iniciar o client
+### Inicando
+Antes de tudo, você precisa obter seu API-Token da Discloud. Você pode criar um novo digitando `.api` no [Servidor da Discloud](https://discord.gg/discloud).
+Se você estiver com problemas para obter seu API-Token, você pode enviar uma DM para o bot de Tickets da Discloud (DisCloud ModMail#6424) no servidor. Os apoiadores estarão felizes em ajudá-lo
 ```python
 import discloud
 discloud_client = discloud.Client("Token", language="pt")
 ```
 
-### Buscar informações do usuário
+### Informações do usuário
 ```python
 user = await discloud_client.fetch_user_info()
 print(f"ID: '{user.id}'")
@@ -24,9 +26,9 @@ print(f"Data de término '{plan.expire_date}'")
 print(f"Termina em '{plan.expires_in}'")
 ```
 
-### Buscar informações do bot
+### Informações do bot
 ```python
-bot = await discloud_client.fetch_bot(bot_id=469310554108854274)
+bot = await discloud_client.fetch_bot(bot_id=BOT_ID)
 print(f"ID '{bot.id}'")
 print(f"Status '{bot.status}'")
 print(f"CPU '{bot.cpu}'")
@@ -38,30 +40,28 @@ print(f"Ultimo reinício '{bot.last_restart}'")
 
 ### Logs
 ```python
-logs = await discloud_client.fetch_logs(bot_id=ID_DO_BOT)
-# você pode usar também
-logs = await bot.fetch_logs()
-
-print(logs.url) # url do logs completo
-
-print(str(logs))
+logs = await discloud_client.fetch_logs(bot_id=BOT_ID)
 # ou
-print(logs.text)
+logs = await bot.fetch_logs()
+print(logs.url) # ".url" para um link com os logs completos
+print(logs.text) # ".text" para os últimos 1800 caractéres do seus logs
 ```
 
 ### Restart
+Para saber se o restart com bem-sucedido, acesse o atributo `.message` de uma Action. 
 ```python
-result = await discloud_client.restart_bot(bot_id=ID_DO_BOT)
-# voce pode usar tambem
+result = await discloud_client.restart_bot(bot_id=BOT_ID)
+# ou
 result = await bot.restart()
-print(result) # voce vai saber se ele foi reiniciado ou não
+print(result.message) # Confirma se o restart foi bem-sucedido
 ```
 
 ### Commit
+`*.commit()` aceita o kwarg `restart`. Defina-o como True para reiniciar o bot após o commit, False para não reiniciar após o commit.
 ```python
-file = discloud.File("arquivo.zip") # precisa ser em zip
-await discloud_client.commit(bot_id=ID_DO_BOT, file=file, restart=True)
-# ou tambem
-r = await bot.commit(file=file, restart=False)
-print(r) # saber se o commit foi um sucesso 
+file = discloud.File("eggs.zip") # Deve ser um .zip
+result = await discloud_client.commit(bot_id=BOT_ID, file=file, restart=True)
+# or
+result = await bot.commit(file=file, restart=True)
+print(result.message) # Confirma se o commit foi bem-sucedido
 ```


### PR DESCRIPTION
Mudei algumas coisas que achei que precisavam ser esclarecidas. Quando comecei a usar esse wrapper, não sabia onde pegar a Key da api, então clarifiquei este tópico também. Melhorei algumas coisas para guiar novos programadores em python para um caminho que eu julgo mais explícito e legível: ao invés de `print(str(logs))`, é `print(logs.text)`

Arrumei inconsistências do README anterior, onde uma mensagem em português era exibida no arquivo em inglês.