### PR TITLE
Adicionar suporte inicial a traduções.

### DIFF
--- a/discloud/discloud_typing.py
+++ b/discloud/discloud_typing.py
@@ -16,7 +16,6 @@ class AppData(TypedDict):
     memory: str
     ssd: str
     netIO: Dict[str, str]
-    last_restart: str
     startedAt: str
 
 

--- a/discloud/errors.py
+++ b/discloud/errors.py
@@ -20,3 +20,7 @@ class RateLimit(RequestError):
 
 class InvalidArgument(DisCloudException):
     pass
+
+
+class TranslatorException(Exception):
+    pass

--- a/discloud/errors.py
+++ b/discloud/errors.py
@@ -20,7 +20,3 @@ class RateLimit(RequestError):
 
 class InvalidArgument(DisCloudException):
     pass
-
-
-class TranslatorException(Exception):
-    pass

--- a/discloud/utils.py
+++ b/discloud/utils.py
@@ -3,7 +3,6 @@ import datetime
 import dateutil.parser
 import requests
 from typing import List, Tuple
-from .errors import InvalidArgument
 from libretranslatepy import LibreTranslateAPI
 
 

--- a/discloud/utils.py
+++ b/discloud/utils.py
@@ -69,7 +69,7 @@ class Translate:
 
         provider = self.get_fast_translator_provider()
 
-        if not provider or string == target:
+        if not provider or target == source:
             return string
         
         translator = LibreTranslateAPI(provider['url'])

--- a/discloud/utils.py
+++ b/discloud/utils.py
@@ -41,6 +41,8 @@ def check_perms(perms) -> Tuple[List[str], List[str]]:
 
 class Translate:
     def get_fast_translator_provider(self) -> dict:
+        """Getting the best translation provider."""
+        
         providers = []
         translators_url = [
             "https://translate.argosopentech.com",
@@ -63,6 +65,8 @@ class Translate:
         return min(providers, key=lambda provider: provider['time']) if len(providers) >= 1 else {}
     
     def translate(self, string: str, target: str, source: str = None) -> str:
+        """Translate the string using the best provider."""
+
         provider = self.get_fast_translator_provider()
 
         if not provider or string == target:

--- a/discloud/utils.py
+++ b/discloud/utils.py
@@ -73,11 +73,12 @@ class Translate:
             return string
         
         translator = LibreTranslateAPI(provider['url'])
+        supported_languages = translator.languages()
 
-        for language in translator.languages():
+        for index, language in enumerate(supported_languages):
             if language['code'] == target:
                 break
-            else:
+            elif len(supported_languages) == index + 1:
                 return string
 
         if source is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 aiohttp
+requests
 setuptools
 python-dateutil
+git+https://github.com/argosopentech/LibreTranslate-py@main


### PR DESCRIPTION
Este PR adiciona o básico para as traduções de strings da biblioteca de forma geral.

Este PR ainda **NÃO** pode ser fundido, isto serve apenas para testes iniciais, e requer uma pequena mudança no retorno de idioma da API da discloud.
Atualmente a API retorna o idioma do cliente no formato `pt-BR` ou `en-US`, e este PR usa uma biblioteca de tradução no qual é usado o formato [ISO-639-1](https://pt.wikipedia.org/wiki/ISO_639#ISO_639-1:2002) (`pt` ou `en`).
